### PR TITLE
Remove deprecated libonig-dev from PHP 8 Dockerfiles

### DIFF
--- a/php/8.1/Dockerfile
+++ b/php/8.1/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libjpeg-dev \
     libfreetype6-dev \
-    libonig-dev \
     libxml2-dev \
     git \
     curl \

--- a/php/8.2/Dockerfile
+++ b/php/8.2/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libjpeg-dev \
     libfreetype6-dev \
-    libonig-dev \
     libxml2-dev \
     git \
     curl \


### PR DESCRIPTION
## Summary
- remove `libonig-dev` from the PHP 8.1 and 8.2 Dockerfiles

## Testing
- `docker build -t php81-test php/8.1` *(fails: `docker: command not found`)*
- `docker build -t php82-test php/8.2` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844a0b6661c8322b70d7c88c0a0ef50